### PR TITLE
Updated trusty64 to Ubuntu 14.04.4 and VMware tools to 9.9.6

### DIFF
--- a/scripts/install_tools.sh
+++ b/scripts/install_tools.sh
@@ -20,8 +20,12 @@ virtualbox () {
 }
 
 vmware () {
-    # Install VMware Tools
-    url="https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/6.0.3/1747349/packages/com.vmware.fusion.tools.linux.zip.tar"
+    # Install VMware Tools - version 9.9.6. because current v10.0.5 deprecates itself
+    # on install to Open VM Tools which itself has a bug as of 2016-03-23.
+    # Bug info here: https://communities.vmware.com/thread/529029?start=0&tstart=0
+    # TODO: Upgrade when fixed to the open-vm-tools Ubuntu package.
+
+    url="https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/7.1.3/3204469/packages/com.vmware.fusion.tools.linux.zip.tar"
     curl -L -o /tmp/com.vmware.fusion.tools.linux.zip.tar --url "${url}"
     tar -xvf /tmp/com.vmware.fusion.tools.linux.zip.tar -C /tmp
     rm -f /tmp/com.vmware.fusion.tools.linux.zip.tar
@@ -30,7 +34,7 @@ vmware () {
     rm -f /tmp/com.vmware.fusion.tools.linux.zip
 
     sudo mount -o loop /tmp/payload/linux.iso /media/cdrom
-    tar -xzvf /media/cdrom/VMwareTools-9.6.2-1688356.tar.gz -C /tmp
+    tar -xzvf /media/cdrom/VMwareTools-9.9.4-3193940.tar.gz -C /tmp
     sudo /tmp/vmware-tools-distrib/vmware-install.pl --default
     umount /media/cdrom
 

--- a/trusty64.json
+++ b/trusty64.json
@@ -1,7 +1,7 @@
 {
   "variables": {
-    "iso_url": "http://releases.ubuntu.com/releases/trusty/ubuntu-14.04-server-amd64.iso",
-    "iso_checksum": "01545fa976c8367b4f0d59169ac4866c",
+    "iso_url": "http://releases.ubuntu.com/releases/trusty/ubuntu-14.04.4-server-amd64.iso",
+    "iso_checksum": "2ac1f3e0de626e54d05065d6f549fa3a",
     "iso_checksum_type": "md5",
     "headless": "true",
     "version": "1.0.0",


### PR DESCRIPTION
Tested on VMware Fusion 8.1.0 (3272237) and Virtualbox 4.3.18.  Because of the recent bugs around VMWare' s HGFS, it's worth explicit mention that guest folders _do_ work.  VMware tools 9.9.6 is an older version as a workaround; current is version 10.0.5.  Built on Packer 0.10.0.  Thanks for making the repo; it was helpful!
